### PR TITLE
Add necessary config "start_date" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ This tap:
     ```json
     {"api_url": "https://gitlab.com/api/v3",
      "private_token": "your-access-token",
-     "projects": "myorg/repo-a myorg/repo-b"}
+     "projects": "myorg/repo-a myorg/repo-b",
+     "start_date": "2017-01-17T00:00:00Z"}
     ```
 
 4. [Optional] Create the initial state file


### PR DESCRIPTION
Following the README and launching the tap breaks without a `start_date` on tap-gitlab==0.2.9  