### PR TITLE
Transform string to unicode

### DIFF
--- a/tap_gitlab/transform.py
+++ b/tap_gitlab/transform.py
@@ -52,7 +52,7 @@ def _type_transform(value, type_schema):
             return None
 
     if type_schema == "string":
-        return str(value)
+        return u"{}".format(value)
 
     if type_schema == "integer":
         return int(value)


### PR DESCRIPTION
Unicode strings like u"S\xe9bastien" breaks this tap. This commit is one take on solving that issue.