### PR TITLE
Added support for groups and group milestones.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ This tap:
   - [Branches](https://docs.gitlab.com/ee/api/branches.html)
   - [Commits](https://docs.gitlab.com/ee/api/commits.html)
   - [Issues](https://docs.gitlab.com/ee/api/issues.html)
-  - [Milestones](https://docs.gitlab.com/ee/api/milestones.html)
   - [Projects](https://docs.gitlab.com/ee/api/projects.html)
+  - [Project milestones](https://docs.gitlab.com/ee/api/milestones.html)
   - [Users](https://docs.gitlab.com/ee/api/users.html)
+  - [Groups](https://docs.gitlab.com/ee/api/group_milestones.html)
+  - [Group Milestones](https://docs.gitlab.com/ee/api/users.html)
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state
 
@@ -34,12 +36,20 @@ This tap:
     Create a JSON file called `config.json` containing:
     - Access token you just created
     - API URL for your GitLab account. If you are using the public gitlab.com this will be `https://gitlab.com/api/v3`
+    - Groups to track (space separated)    
     - Projects to track (space separated)
+    
+    Notes:
+    - either groups or projects need to be provided
+    - filling in 'groups' but leaving 'projects' empty will sync all group projects.
+    - filling in 'projects' but leaving 'groups' empty will sync selected projects.
+    - filling in 'groups' and 'groups' will sync selected projects of those groups.
 
     ```json
     {"api_url": "https://gitlab.com/api/v3",
      "private_token": "your-access-token",
-     "projects": "myorg/repo-a myorg/repo-b",
+    "groups": "myorg mygroup", 
+    "projects": "myorg/repo-a myorg/repo-b",
      "start_date": "2018-01-01T00:00:00Z"}
     ```
 
@@ -53,10 +63,14 @@ This tap:
     {"branches": "2017-01-17T00:00:00Z",
     "commits": "2017-01-17T00:00:00Z",
     "issues": "2017-01-17T00:00:00Z",
-    "milestones": "2017-01-17T00:00:00Z",
     "projects": "2017-01-17T00:00:00Z",
-    "users": "2017-01-17T00:00:00Z"}
+    "project_milestones": "2017-01-17T00:00:00Z", 
+    "users": "2017-01-17T00:00:00Z",
+    "group_milestones": "2017-01-17T00:00:00Z"}
     ```
+    
+    Note:
+    - currently, groups don't have a date field which can be tracked
 
 5. Run the application
 

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -204,18 +204,18 @@ def sync_group(gid, pids):
     with Transformer(pre_hook=format_timestamp) as transformer:
         group = transformer.transform(data, RESOURCES["groups"]["schema"])
 
-        if not pids:
-            #  Get all the projects of the group if none are provided
-            for project in group['projects']:
-                if project['id']:
-                    pids.append(project['id'])
+    if not pids:
+        #  Get all the projects of the group if none are provided
+        for project in group['projects']:
+            if project['id']:
+                pids.append(project['id'])
 
-        for pid in pids:
-            sync_project(pid)
+    for pid in pids:
+        sync_project(pid)
 
-        sync_milestones(group, "group")
+    sync_milestones(group, "group")
 
-        singer.write_record("groups", group, time_extracted=time_extracted)
+    singer.write_record("groups", group, time_extracted=time_extracted)
 
 
 def sync_project(pid):
@@ -227,28 +227,28 @@ def sync_project(pid):
         flatten_id(data, "owner")
         project = transformer.transform(data, RESOURCES["projects"]["schema"])
 
-        state_key = "project_{}".format(project["id"])
+    state_key = "project_{}".format(project["id"])
 
-        #pylint: disable=maybe-no-member
-        last_activity_at = project.get('last_activity_at', project.get('created_at'))
-        if not last_activity_at:
-            raise Exception(
-                #pylint: disable=line-too-long
-                "There is no last_activity_at or created_at field on project {}. This usually means I don't have access to the project."
-                .format(project['id']))
+    #pylint: disable=maybe-no-member
+    last_activity_at = project.get('last_activity_at', project.get('created_at'))
+    if not last_activity_at:
+        raise Exception(
+            #pylint: disable=line-too-long
+            "There is no last_activity_at or created_at field on project {}. This usually means I don't have access to the project."
+            .format(project['id']))
 
 
-        if project['last_activity_at'] >= get_start(state_key):
+    if project['last_activity_at'] >= get_start(state_key):
 
-            sync_branches(project)
-            sync_commits(project)
-            sync_issues(project)
-            sync_milestones(project)
-            sync_users(project)
+        sync_branches(project)
+        sync_commits(project)
+        sync_issues(project)
+        sync_milestones(project)
+        sync_users(project)
 
-            singer.write_record("projects", project, time_extracted=time_extracted)
-            utils.update_state(STATE, state_key, last_activity_at)
-            singer.write_state(STATE)
+        singer.write_record("projects", project, time_extracted=time_extracted)
+        utils.update_state(STATE, state_key, last_activity_at)
+        singer.write_state(STATE)
 
 
 def do_sync():

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -46,14 +46,24 @@ RESOURCES = {
         'schema': load_schema('issues'),
         'key_properties': ['id'],
     },
-    'milestones': {
+    'project_milestones': {
         'url': '/projects/{}/milestones',
+        'schema': load_schema('milestones'),
+        'key_properties': ['id'],
+    },
+    'group_milestones': {
+        'url': '/groups/{}/milestones',
         'schema': load_schema('milestones'),
         'key_properties': ['id'],
     },
     'users': {
         'url': '/projects/{}/users',
         'schema': load_schema('users'),
+        'key_properties': ['id'],
+    },
+    'groups': {
+        'url': '/groups/{}',
+        'schema': load_schema('groups'),
         'key_properties': ['id'],
     },
 }
@@ -63,11 +73,11 @@ LOGGER = singer.get_logger()
 SESSION = requests.Session()
 
 
-def get_url(entity, pid):
-    if not isinstance(pid, int):
-        pid = pid.replace("/", "%2F")
+def get_url(entity, id):
+    if not isinstance(id, int):
+        id = id.replace("/", "%2F")
 
-    return CONFIG['api_url'] + RESOURCES[entity]['url'].format(pid)
+    return CONFIG['api_url'] + RESOURCES[entity]['url'].format(id)
 
 
 def get_start(entity):
@@ -165,15 +175,15 @@ def sync_issues(project):
                 singer.write_record("issues", transformed_row, time_extracted=utils.now())
 
 
-def sync_milestones(project):
-    url = get_url("milestones", project['id'])
+def sync_milestones(entity, element="project"):
+    url = get_url(element + "_milestones", entity['id'])
+
     with Transformer(pre_hook=format_timestamp) as transformer:
         for row in gen_request(url):
-            transformed_row = transformer.transform(row, RESOURCES["milestones"]["schema"])
+            transformed_row = transformer.transform(row, RESOURCES[element + "_milestones"]["schema"])
 
-            if row["updated_at"] >= get_start("project_{}".format(project["id"])):
-                singer.write_record("milestones", transformed_row, time_extracted=utils.now())
-
+            if row["updated_at"] >= get_start(element + "_{}".format(entity["id"])):
+                singer.write_record(element + "_milestones", transformed_row, time_extracted=utils.now())
 
 def sync_users(project):
     url = get_url("users", project['id'])
@@ -183,6 +193,29 @@ def sync_users(project):
             transformed_row = transformer.transform(row, RESOURCES["users"]["schema"])
             project["users"].append(row["id"])
             singer.write_record("users", transformed_row, time_extracted=utils.now())
+
+
+def sync_group(gid, pids):
+    url = CONFIG['api_url'] + RESOURCES["groups"]['url'].format(gid)
+
+    data = request(url).json()
+    time_extracted = utils.now()
+
+    with Transformer(pre_hook=format_timestamp) as transformer:
+        group = transformer.transform(data, RESOURCES["groups"]["schema"])
+
+        if not pids:
+            #  Get all the projects of the group if none are provided
+            for project in group['projects']:
+                if project['id']:
+                    pids.append(project['id'])
+
+        for pid in pids:
+            sync_project(pid)
+
+        sync_milestones(group, "group")
+
+        singer.write_record("groups", group, time_extracted=time_extracted)
 
 
 def sync_project(pid):
@@ -218,27 +251,35 @@ def sync_project(pid):
             singer.write_state(STATE)
 
 
-def do_sync(pids):
+def do_sync():
     LOGGER.info("Starting sync")
+
+    gids = list(filter(None, CONFIG['groups'].split(' ')))
+    pids = list(filter(None, CONFIG['projects'].split(' ')))
 
     for resource, config in RESOURCES.items():
         singer.write_schema(resource, config['schema'], config['key_properties'])
 
-    for pid in pids:
-        sync_project(pid)
+    for gid in gids:
+        sync_group(gid, pids)
+
+    if not gids:
+        # When not syncing groups
+        for pid in pids:
+            sync_project(pid)
 
     LOGGER.info("Sync complete")
 
 
 def main_impl():
-    args = utils.parse_args(["private_token", "projects", "start_date"])
+    args = utils.parse_args(["private_token", "projects", "groups", "start_date"])
 
     CONFIG.update(args.config)
 
     if args.state:
         STATE.update(args.state)
 
-    do_sync(CONFIG['projects'].split(' '))
+    do_sync()
 
 
 def main():

--- a/tap_gitlab/schemas/groups.json
+++ b/tap_gitlab/schemas/groups.json
@@ -1,0 +1,59 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "name": {
+            "type": ["null", "string"]
+        },
+        "path": {
+            "type": ["null", "string"]
+        },
+        "description": {
+            "type": ["null", "string"]
+        },
+        "visibility_level": {
+            "type": ["null", "integer"]
+        },
+        "lfs_enabled": {
+            "type": ["null", "boolean"]
+        },
+        "avatar_url": {
+            "type": ["null", "string"]
+        },
+        "web_url": {
+            "type": ["null", "string"]
+        },
+        "request_access_enabled": {
+            "type": ["null", "boolean"]
+        },
+        "full_name": {
+            "type": ["null", "string"]
+        },
+        "full_path": {
+            "type": ["null", "string"]
+        },
+        "id": {
+            "type": ["null", "integer"]
+        },
+        "projects": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        }
+    }
+}

--- a/tap_gitlab/schemas/groups.json
+++ b/tap_gitlab/schemas/groups.json
@@ -2,7 +2,7 @@
     "type": "object",
     "properties": {
         "id": {
-            "type": "integer"
+            "type": ["null", "integer"]
         },
         "name": {
             "type": ["null", "string"]
@@ -33,9 +33,6 @@
         },
         "full_path": {
             "type": ["null", "string"]
-        },
-        "id": {
-            "type": ["null", "integer"]
         },
         "projects": {
             "anyOf": [

--- a/tap_gitlab/schemas/milestones.json
+++ b/tap_gitlab/schemas/milestones.json
@@ -10,6 +10,9 @@
         "project_id": {
             "type": ["null", "integer"]
         },
+        "group_id": {
+            "type": ["null", "integer"]
+        },
         "title": {
             "type": ["null", "string"]
         },


### PR DESCRIPTION
This PR adds support for Gitlab Groups and Group milestones to the tap. When syncing groups, one can choose between syncing all projects contained in the group, or make a sub-selection of projects.