### PR TITLE
Fix/ignore disabled repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.5.1
-  * Update version of `requests` to `0.20.0` in response to CVE 2018-18074
+  * Update version of `requests` to `2.20.0` in response to CVE 2018-18074
 
 ## 0.5.0
   * Added support for groups and group milestones [#9](https://github.com/singer-io/tap-gitlab/pull/9)

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -91,7 +91,7 @@ def get_start(entity):
 @backoff.on_exception(backoff.expo,
                       (requests.exceptions.RequestException),
                       max_tries=5,
-                      giveup=lambda e: e.response is not None and e.response.status_code != 404 and 400 <= e.response.status_code < 500, # pylint: disable=line-too-long
+                      giveup=lambda e: e.response is not None and 400 <= e.response.status_code < 500, # pylint: disable=line-too-long
                       factor=2)
 def request(url, params=None):
     params = params or {}


### PR DESCRIPTION
Now that Gitlab API returns a 404 status on disabled repository instead of 403, it seems beneficial to only give warnings on disabled repositories instead of throwing an error for GET /branches and /commits. 