### PR TITLE
Update __init__.py

### DIFF
--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -245,9 +245,9 @@ def sync_project(pid):
         sync_commits(project)
         sync_issues(project)
         sync_milestones(project)
-        sync_users(project)
-
+        
         singer.write_record("projects", project, time_extracted=time_extracted)
+        sync_users(project)
         utils.update_state(STATE, state_key, last_activity_at)
         singer.write_state(STATE)
 


### PR DESCRIPTION
When the output of tap-gitlab is used with target-bigquery , it is not able to write the projects table in the bigquery dataset . 

**Command Used:**
tap-gitlab --config ~/config.json  | target-bigquery -c tap-gitlab-bigquery-config.json

**Failed Output:**
INFO Sync complete
Errors: [{'index': 0, 'errors': [{'reason': 'invalid', 'location': 'users', 'debugInfo': '', 'message': 'no such field.'}]}]
Loaded 1 row(s) into samples:branches /projects/avengers-77/datasets/samples/tables/branches
Loaded 9 row(s) into samples:commits /projects/avengers-77/datasets/samples/tables/commits
Loaded 1 row(s) into samples:issues /projects/avengers-77/datasets/samples/tables/issues
Loaded 0 row(s) into samples:project_milestones /projects/avengers-77/datasets/samples/tables/project_milestones
Loaded 0 row(s) into samples:group_milestones /projects/avengers-77/datasets/samples/tables/group_milestones
Loaded 1 row(s) into samples:users /projects/avengers-77/datasets/samples/tables/users
Loaded 1 row(s) into samples:groups /projects/avengers-77/datasets/samples/tables/groups

**After changing the order:**
INFO Sync complete
Loaded 1 row(s) into samples:projects /projects/avengers-77/datasets/samples/tables/projects
Loaded 1 row(s) into samples:branches /projects/avengers-77/datasets/samples/tables/branches
Loaded 9 row(s) into samples:commits /projects/avengers-77/datasets/samples/tables/commits
Loaded 1 row(s) into samples:issues /projects/avengers-77/datasets/samples/tables/issues
Loaded 0 row(s) into samples:project_milestones /projects/avengers-77/datasets/samples/tables/project_milestones
Loaded 0 row(s) into samples:group_milestones /projects/avengers-77/datasets/samples/tables/group_milestones
Loaded 1 row(s) into samples:users /projects/avengers-77/datasets/samples/tables/users
Loaded 1 row(s) into samples:groups /projects/avengers-77/datasets/samples/tables/groups

