### PR TITLE
fix pager processing even in commits API

### DIFF
--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -115,18 +115,19 @@ def request(url, params=None):
 
 
 def gen_request(url):
-    params = {'page': 1}
-    resp = request(url, params)
-    last_page = int(resp.headers.get('X-Total-Pages', 1))
-
-    for row in resp.json():
-        yield row
-
-    for page in range(2, last_page + 1):
-        params['page'] = page
+    flag = False
+    page = 1
+    while flag == False:         
+        params = {'page': page}
         resp = request(url, params)
         for row in resp.json():
             yield row
+        if (page + 1 == int('0' + resp.headers.get('x-next-page'))):
+            flag = False
+        else:
+            flag = True
+        page += 1
+
 
 def format_timestamp(data, typ, schema):
     result = data


### PR DESCRIPTION
Fixed pager to work with commits API.  
The commits API does not have an `X-Total-Pages` or `X-Total` property in the header.  
This prevents the pager from functioning properly.

https://gitlab.com/gitlab-org/gitlab/-/issues/264375