### PR TITLE
Update testing infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,14 @@ jobs:
       - run:
           name: 'Setup'
           command: |
-            uv venv --python=3.9 ~/.virtualenvs/tap-gitlab
-            source ~/.virtualenvs/tap-gitlab/bin/activate
+            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-gitlab
+            source /usr/local/share/tap-gitlab/bin/activate
             pip install .
             pip install pylint
       - run:
           name: 'Pylint'
           command: |
-            source ~/.virtualenvs/tap-gitlab/bin/activate
+            source /usr/local/share/tap-gitlab/bin/activate
             pylint tap_gitlab --disable missing-docstring,logging-format-interpolation,locally-disabled,line-too-long,fixme,consider-using-f-string,redefined-builtin,use-yield-from,broad-exception-raised
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup'
           command: |
-            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-gitlab
+            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-gitlab
             source /usr/local/share/virtualenvs/tap-gitlab/bin/activate
             uv pip install .
             uv pip install pylint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup'
           command: |
-            virtualenv -p python3 ~/.virtualenvs/tap-gitlab
+            uv venv --python=3.9 ~/.virtualenvs/tap-gitlab
             source ~/.virtualenvs/tap-gitlab/bin/activate
             pip install .
             pip install pylint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,13 @@ jobs:
           name: 'Setup'
           command: |
             uv venv --python=3.9 /usr/local/share/virtualenvs/tap-gitlab
-            source /usr/local/share/tap-gitlab/bin/activate
+            source /usr/local/share/virtualenvs/tap-gitlab/bin/activate
             uv pip install .
             uv pip install pylint
       - run:
           name: 'Pylint'
           command: |
-            source /usr/local/share/tap-gitlab/bin/activate
+            source /usr/local/share/virtualenvs/tap-gitlab/bin/activate
             pylint tap_gitlab --disable missing-docstring,logging-format-interpolation,locally-disabled,line-too-long,fixme,consider-using-f-string,redefined-builtin,use-yield-from,broad-exception-raised
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
           command: |
             uv venv --python=3.9 /usr/local/share/virtualenvs/tap-gitlab
             source /usr/local/share/tap-gitlab/bin/activate
-            pip install .
-            pip install pylint
+            uv pip install .
+            uv pip install pylint
       - run:
           name: 'Pylint'
           command: |


### PR DESCRIPTION
This PR updates the CircleCI config to use `uv` to create and manage virtualenvs and python dependencies