### PR TITLE
SAC-28836: Add parent-tap-stream-id key in metadata

### DIFF
--- a/tap_gitlab/schema.py
+++ b/tap_gitlab/schema.py
@@ -97,6 +97,11 @@ def get_schemas() -> Tuple[Dict, Dict]:
                     mdata, ("properties", field_name), "inclusion", "automatic"
                 )
 
+        # Check if the stream has any parent attribute
+        parent_attribute = getattr(stream_obj, "parent", None)
+        if parent_attribute:
+            mdata = metadata.write(mdata, (), "parent-tap-stream-id", parent_attribute)
+
         field_metadata[stream_name] = metadata.to_list(mdata)
 
     return schemas, field_metadata


### PR DESCRIPTION
# Description of change
This PR include changes to accommodate parent-tap-stream-id key along with forced-replication-method key in the metadata. Please find the issue link here: https://qlik-dev.atlassian.net/browse/SAC-28836

# Changes

- Updated schema.py file to include additional metadata attributes
- Verified the forced-replication-method key being populated in metadata

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
