### PR TITLE
Moves private token from the params to the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 1.1.1
  * Moves private token from the params to the header "PRIVATE-TOKEN" [#54](https://github.com/singer-io/tap-gitlab/pull/54)
+ * Improved error parsing to surface the actual GitLab error message when available.
 
 # 1.1.0
   * Add optional `api_url` config field to support on-premises GitLab instances; defaults to `https://gitlab.com`. [#51](https://github.com/singer-io/tap-gitlab/pull/51)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+# 1.1.1
+ * Moves private token from the params to the header "PRIVATE-TOKEN" [#54](https://github.com/singer-io/tap-gitlab/pull/54)
 
 # 1.1.0
   * Add optional `api_url` config field to support on-premises GitLab instances; defaults to `https://gitlab.com`. [#51](https://github.com/singer-io/tap-gitlab/pull/51)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 # 1.1.1
- * Moves private token from the params to the header "PRIVATE-TOKEN" [#54](https://github.com/singer-io/tap-gitlab/pull/54)
- * Improved error parsing to surface the actual GitLab error message when available.
+ * Moved the private token from query parameters to the `PRIVATE-TOKEN` request header for improved security. [#54](https://github.com/singer-io/tap-gitlab/pull/54)
+ * Enhanced error handling to extract and display the underlying GitLab API error message when present.
 
 # 1.1.0
   * Add optional `api_url` config field to support on-premises GitLab instances; defaults to `https://gitlab.com`. [#51](https://github.com/singer-io/tap-gitlab/pull/51)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tap-gitlab',
-    version='1.1.0',
+    version='1.1.1',
     description='Singer.io tap for extracting data from the GitLab API',
     author='Stitch',
     url='https://singer.io',

--- a/tap_gitlab/client.py
+++ b/tap_gitlab/client.py
@@ -98,8 +98,7 @@ class Client:
 
     def check_api_credentials(self) -> None:
         """Verify API credentials by making a test request."""
-        headers = {}
-        params = {'private_token': self.config.get("private_token")}
+        headers, params = self.authenticate({}, {})
         endpoint = f"{self.base_url}/user"
 
         try:
@@ -124,7 +123,9 @@ class Client:
     def authenticate(self, headers: Dict, params: Dict) -> Tuple[Dict, Dict]:
         """Authenticates the request using dynamic header/token keys."""
         params = params or {}
-        params['private_token'] = self.config.get("private_token")
+        private_token = self.config.get("private_token")
+        if private_token:
+            headers["PRIVATE-TOKEN"] = private_token
 
         if isinstance(headers, dict) and "user_agent" in self.config:
             headers["User-Agent"] = self.config.get("user_agent")

--- a/tap_gitlab/client.py
+++ b/tap_gitlab/client.py
@@ -67,6 +67,7 @@ def raise_for_error(response: requests.Response) -> None:
             raw_body = getattr(response, 'text', None)
             message = f"HTTP-error-code: {response.status_code}, Error: {fallback}"
             if raw_body:
+                # Truncated error logs to 200 chars to avoid flooding logs with large HTML error pages
                 message += f" (Response body: {raw_body[:200]})"
         exc = ERROR_CODE_EXCEPTION_MAPPING.get(response.status_code, {}).get("raise_exception", Error)
         raise exc(message, response) from None

--- a/tap_gitlab/client.py
+++ b/tap_gitlab/client.py
@@ -58,8 +58,16 @@ def raise_for_error(response: requests.Response) -> None:
     if response.status_code not in [200, 201, 204]:
         if response_json.get("error"):
             message = f"HTTP-error-code: {response.status_code}, Error: {response_json.get('error')}"
+            if response_json.get("error_description"):
+                message += f" - {response_json.get('error_description')}"
+        elif response_json.get("message"):
+            message = f"HTTP-error-code: {response.status_code}, Error: {response_json.get('message')}"
         else:
-            message = f"HTTP-error-code: {response.status_code}, Error: {response_json.get('message', ERROR_CODE_EXCEPTION_MAPPING.get(response.status_code, {}).get('message', 'Unknown Error'))}"
+            fallback = ERROR_CODE_EXCEPTION_MAPPING.get(response.status_code, {}).get('message', 'Unknown Error')
+            raw_body = getattr(response, 'text', None)
+            message = f"HTTP-error-code: {response.status_code}, Error: {fallback}"
+            if raw_body:
+                message += f" (Response body: {raw_body[:200]})"
         exc = ERROR_CODE_EXCEPTION_MAPPING.get(response.status_code, {}).get("raise_exception", Error)
         raise exc(message, response) from None
 

--- a/tap_gitlab/exceptions.py
+++ b/tap_gitlab/exceptions.py
@@ -109,7 +109,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     },
     403: {
         "raise_exception": ForbiddenError,
-        "message": "You are missing the following required scopes: read"
+        "message": "You are missing the required scopes"
     },
     404: {
         "raise_exception": NotFoundError,

--- a/tap_gitlab/streams/groups.py
+++ b/tap_gitlab/streams/groups.py
@@ -55,6 +55,7 @@ class Groups(FullTableStream):
         for group_id in group_ids:
             try:
                 self._current_group_id = group_id
+                LOGGER.info(f"Syncing group: {group_id}")
                 endpoint = self.get_url_endpoint()
                 response = self.client.get(endpoint, self.params, self.headers, None)
 

--- a/tap_gitlab/streams/projects.py
+++ b/tap_gitlab/streams/projects.py
@@ -57,6 +57,7 @@ class Projects(IncrementalStream):
 
         for project_id in project_ids:
             self._current_project_id = project_id
+            LOGGER.info(f"Syncing project: {project_id}")
             endpoint = self.get_url_endpoint()
             response = self.client.get(endpoint, self.params, self.headers, None)
 

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -185,3 +185,53 @@ class TestCheckApiCredentials(unittest.TestCase):
         # Raw urllib3 message must not be included to avoid token leakage
         self.assertNotIn("Failed to resolve", msg)
         self.assertNotIn("private_token", msg)
+
+
+class TestAuthenticate(unittest.TestCase):
+
+    def _make_client(self, config=None):
+        """Return a Client without triggering check_api_credentials."""
+        return Client(config if config is not None else {"private_token": "secret_token"})
+
+    def test_private_token_set_in_header(self):
+        """private_token must be sent in the PRIVATE-TOKEN header, not as a query param."""
+        client = self._make_client({"private_token": "secret_token"})
+        headers, params = client.authenticate({}, {})
+        self.assertEqual(headers.get("PRIVATE-TOKEN"), "secret_token")
+
+    def test_private_token_not_in_params(self):
+        """private_token must never appear in the query parameters."""
+        client = self._make_client({"private_token": "secret_token"})
+        headers, params = client.authenticate({}, {})
+        self.assertNotIn("private_token", params)
+
+    def test_no_private_token_in_config_leaves_header_unset(self):
+        """When private_token is absent from config the header must not be added."""
+        client = self._make_client({})
+        headers, params = client.authenticate({}, {})
+        self.assertNotIn("PRIVATE-TOKEN", headers)
+
+    def test_user_agent_added_to_headers_when_configured(self):
+        """user_agent in config must be forwarded as the User-Agent header."""
+        client = self._make_client({"private_token": "t", "user_agent": "my-tap/1.0"})
+        headers, params = client.authenticate({}, {})
+        self.assertEqual(headers.get("User-Agent"), "my-tap/1.0")
+
+    def test_existing_headers_are_preserved(self):
+        """authenticate() must not discard headers that were already set by the caller."""
+        client = self._make_client({"private_token": "secret_token"})
+        headers, params = client.authenticate({"Accept": "application/json"}, {})
+        self.assertEqual(headers.get("Accept"), "application/json")
+        self.assertEqual(headers.get("PRIVATE-TOKEN"), "secret_token")
+
+    @patch("requests.Session.get")
+    def test_request_uses_header_not_param(self, mock_get):
+        """End-to-end: an actual GET must carry PRIVATE-TOKEN in the header, not in the URL."""
+        mock_get.return_value = get_mock_response(200, {"id": 1, "username": "tester"})
+        client = self._make_client({"private_token": "secret_token"})
+        client.check_api_credentials()
+        _, call_kwargs = mock_get.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        sent_params = call_kwargs.get("params", {})
+        self.assertEqual(sent_headers.get("PRIVATE-TOKEN"), "secret_token")
+        self.assertNotIn("private_token", sent_params)


### PR DESCRIPTION
# Description of change
PR include fix involves two changes: update `authenticate` to pass the token via `PRIVATE-TOKEN` header instead of params, and simplify `check_api_credentials` to reuse authenticate. [SAC-31453](https://qlik-dev.atlassian.net/browse/SAC-31453)

Updated the exception handling in tap_gitlab/exceptions.py. Improved error parsing to surface the actual GitLab error message when available. Retained the fallback behavior only when no meaningful error message can be extracted from the response. [SAC-31205](https://qlik-dev.atlassian.net/browse/SAC-31205)

# Manual QA steps
- [x] - Discovery: Running
- [x] - Sync: Running
- [x] - Unit tests: Running
- [x] - Integration Tests: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
